### PR TITLE
Upgrade patch-versions of Scala, Scalaz, FS2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ name := "fs2-scalaz"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.11.8", "2.12.0")
+crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 scalacOptions ++= Seq(
   "-feature",
@@ -33,9 +33,9 @@ scalacOptions in (Compile, console) ~= {_.filterNot("-Ywarn-unused-import" == _)
 scalacOptions in (Test, console) <<= (scalacOptions in (Compile, console))
 
 resolvers += "Sonatype Public" at "https://oss.sonatype.org/content/groups/public/"
-val scalazVersion = "7.2.7"
+val scalazVersion = "7.2.9"
 libraryDependencies ++= Seq(
-  "co.fs2"     %% "fs2-core"          % "0.9.2",
+  "co.fs2"     %% "fs2-core"          % "0.9.4",
   "org.scalaz" %% "scalaz-core"       % scalazVersion,
   "org.scalaz" %% "scalaz-concurrent" % scalazVersion
 )


### PR DESCRIPTION
Scala 2.12.0 -> 2.12.1
Scalaz 7.2.7 -> 7.2.9
FS2 0.9.2 -> 0.9.4