### PR TITLE
Port of functional-streams-for-scala/fs2-cats#19

### DIFF
--- a/src/main/scala/fs2/interop/scalaz/Instances.scala
+++ b/src/main/scala/fs2/interop/scalaz/Instances.scala
@@ -12,7 +12,7 @@ trait Instances extends Instances0 {
     def handleError[A](fa: F[A])(f: Throwable => F[A]) = F.flatMap(F.attempt(fa))(e => e.fold(f, F.pure))
   }
 
-  implicit def uf1ToNatrualTransformation[F[_], G[_]](implicit uf1: UF1[F, G]): NaturalTransformation[F, G] = new NaturalTransformation[F, G] {
+  implicit def uf1ToNatrualTransformation[F[_], G[_]](uf1: UF1[F, G]): NaturalTransformation[F, G] = new NaturalTransformation[F, G] {
     def apply[A](fa: F[A]) = uf1(fa)
   }
 }

--- a/src/main/scala/fs2/interop/scalaz/ReverseInstances.scala
+++ b/src/main/scala/fs2/interop/scalaz/ReverseInstances.scala
@@ -13,7 +13,7 @@ trait ReverseInstances extends ReverseInstances0 {
     def attempt[A](fa: F[A]) = F.handleError(F.map(fa)(a => Right(a): Either[Throwable, A]))(t => pure(Left(t)))
   }
 
-  implicit def naturalTransformationToUf1[F[_], G[_]](implicit nt: NaturalTransformation[F, G]): UF1[F, G] = new UF1[F, G] {
+  implicit def naturalTransformationToUf1[F[_], G[_]](nt: NaturalTransformation[F, G]): UF1[F, G] = new UF1[F, G] {
     def apply[A](fa: F[A]) = nt(fa)
   }
 }


### PR DESCRIPTION
Ported the changes from  functional-streams-for-scala/fs2-cats#19, implicit conversions of natural transformations should work as expected now.